### PR TITLE
Simplify metadata checks and update test mocks

### DIFF
--- a/go/internal/aws/multipart.go
+++ b/go/internal/aws/multipart.go
@@ -40,7 +40,7 @@ func (cm *ClientManager) CreateMultipartUpload(ctx context.Context, bucket, key,
 		ContentType: aws.String(contentType),
 	}
 
-	if metadata != nil && len(metadata) > 0 {
+	if len(metadata) > 0 {
 		input.Metadata = metadata
 	}
 


### PR DESCRIPTION
Refactor metadata checks to remove unnecessary nil checks and update mock implementations for better alignment with actual S3 object handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * メタデータの割り当て条件を簡素化し、冗長なnilチェックを削除しました。
  * 未使用のヘルパー関数と不要なインポートを削除し、コードの可読性を向上させました。

* **テスト**
  * モックのS3操作の戻り値をAWS SDKのオブジェクト構造体に変更し、より実際の挙動に近づけました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->